### PR TITLE
Сделал запуск тестов проще

### DIFF
--- a/cs/Chess/Chess.csproj
+++ b/cs/Chess/Chess.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>8</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6</TargetFramework>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 

--- a/cs/Chess/Chess.csproj
+++ b/cs/Chess/Chess.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
       <PackageReference Include="NUnit" Version="3.12.0" />
-      <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     </ItemGroup>
 
 </Project>

--- a/cs/ControlDigit/ControlDigit.csproj
+++ b/cs/ControlDigit/ControlDigit.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>8</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6</TargetFramework>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 

--- a/cs/ControlDigit/ControlDigit.csproj
+++ b/cs/ControlDigit/ControlDigit.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
       <PackageReference Include="NUnit" Version="3.12.0" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     </ItemGroup>
 
 </Project>

--- a/cs/Samples/Samples.csproj
+++ b/cs/Samples/Samples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>8</LangVersion>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6</TargetFramework>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 

--- a/cs/Samples/Samples.csproj
+++ b/cs/Samples/Samples.csproj
@@ -6,4 +6,8 @@
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Сейчас новые разработчики вероятней установят net6 sdk, чем net3.1.
Также в некоторых конфигурациях ide-sdk запуск тестов без `NUnit3TestAdapter` невозможен или затруднен. На практике часто приходится помогать ребятам с запуском тестов